### PR TITLE
[WIP] CMake Modernization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 *.so
 /doc/html/
 *build*/
+/.vs
+/CMakeSettings.json

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.os
 *.so
 /doc/html/
+*build*/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,7 @@ set( SFGUI_VERSION ${SFGUI_MAJOR_VERSION}.${SFGUI_MINOR_VERSION}.${SFGUI_REVISIO
 ### USER INPUT ###
 
 option( SFGUI_BUILD_SHARED_LIBS "Build shared library."                         ON )
-set(BUILD_SHARED_LIBS ${SFGUI_BUILD_SHARED_LIBS})
+set( BUILD_SHARED_LIBS ${SFGUI_BUILD_SHARED_LIBS} )
 option( SFGUI_BUILD_EXAMPLES    "Build examples."                               ON)
 option( SFGUI_BUILD_DOC         "Generate API documentation."                   OFF)
 option( SFGUI_INCLUDE_FONT      "Include default font in library (DejaVuSans)." ON)
@@ -44,7 +44,7 @@ target_include_directories( ${TARGET} PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/lib
 target_include_directories( ${TARGET} PUBLIC $<BUILD_INTERFACE:${INCLUDE_PATH}> $<INSTALL_INTERFACE:include/> )
 
 if( NOT SFGUI_BUILD_SHARED_LIBS )
-	target_compile_definitions( ${TARGET} PRIVATE SFGUI_STATIC )
+	target_compile_definitions( ${TARGET} PUBLIC SFGUI_STATIC )
 	set_target_properties( ${TARGET} PROPERTIES DEBUG_POSTFIX -s-d )
 	set_target_properties( ${TARGET} PROPERTIES RELEASE_POSTFIX -s )
 	set_target_properties( ${TARGET} PROPERTIES MINSIZEREL_POSTFIX -s )
@@ -76,7 +76,7 @@ if( WIN32 )
 		if( SFGUI_BUILD_SHARED_LIBS )
 			message( FATAL_ERROR "\n-> SFGUI_STATIC_STD_LIBS and SFGUI_BUILD_SHARED_LIBS are not compatible.\n-> They lead to multiple runtime environments which results in undefined behavior.\n" )
 		else()
-			target_compile_definitions( ${TARGET} PRIVATE SFML_STATIC )
+			target_compile_definitions( ${TARGET} PUBLIC SFML_STATIC )
 
 			if( MSVC )
 				foreach( flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -179,10 +179,10 @@ write_basic_package_version_file( ${PROJECT_NAME}ConfigVersion.cmake
 	VERSION ${SFGUI_VERSION}
 	COMPATIBILITY SameMajorVersion )
 
-configure_file(cmake/templates/config.cmake.in ${PROJECT_NAME}Config.cmake @ONLY)
+configure_file(cmake/templates/config.cmake.in "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" @ONLY)
 
 install(
-	FILES ${PROJECT_NAME}Config.cmake ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+	FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}Config.cmake" "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake"
 	DESTINATION "${SHARE_PATH}/cmake/"
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,224 +1,69 @@
-cmake_minimum_required( VERSION 2.8 )
-project( SFGUI )
+cmake_minimum_required( VERSION 3.2 )
+project( SFGUI CXX )
+set(TARGET SFGUI)
+
+set( CMAKE_CXX_STANDARD 11 )
+set( CMAKE_CXX_STANDARD_REQUIRED ON )
+set( CMAKE_CXX_EXTENSIONS OFF )
 
 set( SFGUI_MAJOR_VERSION 0 )
 set( SFGUI_MINOR_VERSION 3 )
 set( SFGUI_REVISION_VERSION 2 )
+set( SFGUI_VERSION ${SFGUI_MAJOR_VERSION}.${SFGUI_MINOR_VERSION}.${SFGUI_REVISION_VERSION} )
 
 ### USER INPUT ###
 
-set( SFGUI_BUILD_SHARED_LIBS true CACHE BOOL "Build shared library." )
-set( SFGUI_BUILD_EXAMPLES true CACHE BOOL "Build examples." )
-set( SFGUI_BUILD_DOC false CACHE BOOL "Generate API documentation." )
-set( SFGUI_INCLUDE_FONT true CACHE BOOL "Include default font in library (DejaVuSans)." )
-set( SFML_STATIC_LIBRARIES false CACHE BOOL "Do you want to link SFML statically?" )
+option( SFGUI_BUILD_SHARED_LIBS "Build shared library."                         ON )
+set(BUILD_SHARED_LIBS ${SFGUI_BUILD_SHARED_LIBS})
+option( SFGUI_BUILD_EXAMPLES    "Build examples."                               ON)
+option( SFGUI_BUILD_DOC         "Generate API documentation."                   OFF)
+option( SFGUI_INCLUDE_FONT      "Include default font in library (DejaVuSans)." ON)
+option( SFML_STATIC_LIBRARIES   "Do you want to link SFML statically?"          OFF)
 
-# Automatically grab SFML_DIR from the environment if it exists, or force the user to specify it if it doesn't.
-set( SFML_DIR "$ENV{SFML_DIR}" CACHE PATH "SFML root directory." )
-
-if( "${SFML_DIR}" STREQUAL "" )
-	message( FATAL_ERROR "The SFML_DIR environment variable was not found. Please set SFML_DIR to the directory where SFML is located." )
-endif()
 
 # Find packages.
 find_package( OpenGL REQUIRED )
 find_package( SFML 2.5 REQUIRED COMPONENTS graphics window system )
 
-# Find X11 for glX on Linux, checking for UNIX would match other UNIX systems as well
-if( "${CMAKE_SYSTEM_NAME}" MATCHES "Linux" )
-	find_package( X11 REQUIRED )
-endif()
+set( INCLUDE_PATH "${PROJECT_SOURCE_DIR}/include/" )
+set( SOURCE_PATH "${PROJECT_SOURCE_DIR}/src/" )
+
+file(GLOB_RECURSE HPPS "${INCLUDE_PATH}/*.hpp")
+file(GLOB_RECURSE INLS "${INCLUDE_PATH}/*.inl")
+file(GLOB_RECURSE CPPS "${SOURCE_PATH}/*.cpp")
 
 if( SFGUI_INCLUDE_FONT )
-	add_definitions( -DSFGUI_INCLUDE_FONT )
+	list(APPEND CPPS "${SOURCE_PATH}/SFGUI/DejaVuSansFont.cpp")
 endif()
-
-set( INCLUDE_PATH "${PROJECT_SOURCE_DIR}/include" )
-set( SOURCE_PATH "${PROJECT_SOURCE_DIR}/src" )
-
-set(
-	SOURCES
-	"${INCLUDE_PATH}/SFGUI/Adjustment.hpp"
-	"${INCLUDE_PATH}/SFGUI/Alignment.hpp"
-	"${INCLUDE_PATH}/SFGUI/Bin.hpp"
-	"${INCLUDE_PATH}/SFGUI/Box.hpp"
-	"${INCLUDE_PATH}/SFGUI/Button.hpp"
-	"${INCLUDE_PATH}/SFGUI/Canvas.hpp"
-	"${INCLUDE_PATH}/SFGUI/CheckButton.hpp"
-	"${INCLUDE_PATH}/SFGUI/ComboBox.hpp"
-	"${INCLUDE_PATH}/SFGUI/Config.hpp"
-	"${INCLUDE_PATH}/SFGUI/Container.hpp"
-	"${INCLUDE_PATH}/SFGUI/Context.hpp"
-	"${INCLUDE_PATH}/SFGUI/Desktop.hpp"
-	"${INCLUDE_PATH}/SFGUI/Desktop.inl"
-	"${INCLUDE_PATH}/SFGUI/Engine.hpp"
-	"${INCLUDE_PATH}/SFGUI/Engine.inl"
-	"${INCLUDE_PATH}/SFGUI/Engines/BREW.hpp"
-	"${INCLUDE_PATH}/SFGUI/Entry.hpp"
-	"${INCLUDE_PATH}/SFGUI/FileResourceLoader.hpp"
-	"${INCLUDE_PATH}/SFGUI/Fixed.hpp"
-	"${INCLUDE_PATH}/SFGUI/Frame.hpp"
-	"${INCLUDE_PATH}/SFGUI/Image.hpp"
-	"${INCLUDE_PATH}/SFGUI/Label.hpp"
-	"${INCLUDE_PATH}/SFGUI/Misc.hpp"
-	"${INCLUDE_PATH}/SFGUI/Notebook.hpp"
-	"${INCLUDE_PATH}/SFGUI/Object.hpp"
-	"${INCLUDE_PATH}/SFGUI/Primitive.hpp"
-	"${INCLUDE_PATH}/SFGUI/PrimitiveTexture.hpp"
-	"${INCLUDE_PATH}/SFGUI/PrimitiveVertex.hpp"
-	"${INCLUDE_PATH}/SFGUI/ProgressBar.hpp"
-	"${INCLUDE_PATH}/SFGUI/RadioButton.hpp"
-	"${INCLUDE_PATH}/SFGUI/RadioButtonGroup.hpp"
-	"${INCLUDE_PATH}/SFGUI/Range.hpp"
-	"${INCLUDE_PATH}/SFGUI/RenderQueue.hpp"
-	"${INCLUDE_PATH}/SFGUI/Renderer.hpp"
-	"${INCLUDE_PATH}/SFGUI/Renderers.hpp"
-	"${INCLUDE_PATH}/SFGUI/RendererTextureNode.hpp"
-	"${INCLUDE_PATH}/SFGUI/RendererViewport.hpp"
-	"${INCLUDE_PATH}/SFGUI/Renderers/NonLegacyRenderer.hpp"
-	"${INCLUDE_PATH}/SFGUI/Renderers/VertexArrayRenderer.hpp"
-	"${INCLUDE_PATH}/SFGUI/Renderers/VertexBufferRenderer.hpp"
-	"${INCLUDE_PATH}/SFGUI/ResourceLoader.hpp"
-	"${INCLUDE_PATH}/SFGUI/ResourceManager.hpp"
-	"${INCLUDE_PATH}/SFGUI/ResourceManager.inl"
-	"${INCLUDE_PATH}/SFGUI/SFGUI.hpp"
-	"${INCLUDE_PATH}/SFGUI/Scale.hpp"
-	"${INCLUDE_PATH}/SFGUI/Scrollbar.hpp"
-	"${INCLUDE_PATH}/SFGUI/ScrolledWindow.hpp"
-	"${INCLUDE_PATH}/SFGUI/Selector.hpp"
-	"${INCLUDE_PATH}/SFGUI/Separator.hpp"
-	"${INCLUDE_PATH}/SFGUI/Signal.hpp"
-	"${INCLUDE_PATH}/SFGUI/SpinButton.hpp"
-	"${INCLUDE_PATH}/SFGUI/Spinner.hpp"
-	"${INCLUDE_PATH}/SFGUI/Table.hpp"
-	"${INCLUDE_PATH}/SFGUI/TableCell.hpp"
-	"${INCLUDE_PATH}/SFGUI/TableOptions.hpp"
-	"${INCLUDE_PATH}/SFGUI/ToggleButton.hpp"
-	"${INCLUDE_PATH}/SFGUI/Viewport.hpp"
-	"${INCLUDE_PATH}/SFGUI/Widget.hpp"
-	"${INCLUDE_PATH}/SFGUI/Widgets.hpp"
-	"${INCLUDE_PATH}/SFGUI/Window.hpp"
-	"${SOURCE_PATH}/SFGUI/Adjustment.cpp"
-	"${SOURCE_PATH}/SFGUI/Alignment.cpp"
-	"${SOURCE_PATH}/SFGUI/Bin.cpp"
-	"${SOURCE_PATH}/SFGUI/Box.cpp"
-	"${SOURCE_PATH}/SFGUI/Button.cpp"
-	"${SOURCE_PATH}/SFGUI/Canvas.cpp"
-	"${SOURCE_PATH}/SFGUI/CheckButton.cpp"
-	"${SOURCE_PATH}/SFGUI/ComboBox.cpp"
-	"${SOURCE_PATH}/SFGUI/Container.cpp"
-	"${SOURCE_PATH}/SFGUI/Context.cpp"
-	"${SOURCE_PATH}/SFGUI/DejaVuSansFont.hpp"
-	"${SOURCE_PATH}/SFGUI/Desktop.cpp"
-	"${SOURCE_PATH}/SFGUI/Engine.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Button.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/CheckButton.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/ComboBox.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Entry.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Frame.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Image.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Label.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Notebook.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/ProgressBar.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Scale.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Scrollbar.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/ScrolledWindow.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Separator.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/SpinButton.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Spinner.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/ToggleButton.cpp"
-	"${SOURCE_PATH}/SFGUI/Engines/BREW/Window.cpp"
-	"${SOURCE_PATH}/SFGUI/Entry.cpp"
-	"${SOURCE_PATH}/SFGUI/FileResourceLoader.cpp"
-	"${SOURCE_PATH}/SFGUI/Fixed.cpp"
-	"${SOURCE_PATH}/SFGUI/Frame.cpp"
-	"${SOURCE_PATH}/SFGUI/GLCheck.cpp"
-	"${SOURCE_PATH}/SFGUI/GLCheck.hpp"
-	"${SOURCE_PATH}/SFGUI/GLLoader.cpp"
-	"${SOURCE_PATH}/SFGUI/GLLoader.hpp"
-	"${SOURCE_PATH}/SFGUI/Image.cpp"
-	"${SOURCE_PATH}/SFGUI/Label.cpp"
-	"${SOURCE_PATH}/SFGUI/Misc.cpp"
-	"${SOURCE_PATH}/SFGUI/Notebook.cpp"
-	"${SOURCE_PATH}/SFGUI/Object.cpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/Grammar.cpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/Grammar.hpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/GrammarPredicates.cpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/GrammarSelector.cpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/GrammarSimpleSelector.cpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/GrammarStatement.cpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/GrammarToken.cpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/Parse.cpp"
-	"${SOURCE_PATH}/SFGUI/Parsers/ThemeParser/Parse.hpp"
-	"${SOURCE_PATH}/SFGUI/Primitive.cpp"
-	"${SOURCE_PATH}/SFGUI/PrimitiveTexture.cpp"
-	"${SOURCE_PATH}/SFGUI/PrimitiveVertex.cpp"
-	"${SOURCE_PATH}/SFGUI/ProgressBar.cpp"
-	"${SOURCE_PATH}/SFGUI/RadioButton.cpp"
-	"${SOURCE_PATH}/SFGUI/RadioButtonGroup.cpp"
-	"${SOURCE_PATH}/SFGUI/Range.cpp"
-	"${SOURCE_PATH}/SFGUI/RenderQueue.cpp"
-	"${SOURCE_PATH}/SFGUI/Renderer.cpp"
-	"${SOURCE_PATH}/SFGUI/RendererBatch.hpp"
-	"${SOURCE_PATH}/SFGUI/RendererViewport.cpp"
-	"${SOURCE_PATH}/SFGUI/Renderers/NonLegacyRenderer.cpp"
-	"${SOURCE_PATH}/SFGUI/Renderers/VertexArrayRenderer.cpp"
-	"${SOURCE_PATH}/SFGUI/Renderers/VertexBufferRenderer.cpp"
-	"${SOURCE_PATH}/SFGUI/ResourceManager.cpp"
-	"${SOURCE_PATH}/SFGUI/SFGUI.cpp"
-	"${SOURCE_PATH}/SFGUI/Scale.cpp"
-	"${SOURCE_PATH}/SFGUI/Scrollbar.cpp"
-	"${SOURCE_PATH}/SFGUI/ScrolledWindow.cpp"
-	"${SOURCE_PATH}/SFGUI/Selector.cpp"
-	"${SOURCE_PATH}/SFGUI/Separator.cpp"
-	"${SOURCE_PATH}/SFGUI/Signal.cpp"
-	"${SOURCE_PATH}/SFGUI/SpinButton.cpp"
-	"${SOURCE_PATH}/SFGUI/Spinner.cpp"
-	"${SOURCE_PATH}/SFGUI/Table.cpp"
-	"${SOURCE_PATH}/SFGUI/TableCell.cpp"
-	"${SOURCE_PATH}/SFGUI/TableOptions.cpp"
-	"${SOURCE_PATH}/SFGUI/ToggleButton.cpp"
-	"${SOURCE_PATH}/SFGUI/Viewport.cpp"
-	"${SOURCE_PATH}/SFGUI/Widget.cpp"
-	"${SOURCE_PATH}/SFGUI/Window.cpp"
-)
-
-if( SFGUI_INCLUDE_FONT )
-	set(
-		SOURCES
-		${SOURCES}
-		"${SOURCE_PATH}/SFGUI/DejaVuSansFont.cpp"
-	)
-endif()
-
-include_directories( "${INCLUDE_PATH}" )
-include_directories( "${SOURCE_PATH}" )
-include_directories( SYSTEM "${PROJECT_SOURCE_DIR}/extlibs/libELL/include" )
 
 # Set the library output directory
 set( LIBRARY_OUTPUT_PATH "${PROJECT_BINARY_DIR}/lib" )
 
-# Add the library.
-if( SFGUI_BUILD_SHARED_LIBS )
-	add_library( sfgui SHARED ${SOURCES} )
+add_library( ${TARGET} ${CPPS} ${INLS} ${HPPS} )
+target_include_directories( ${TARGET} PRIVATE "${PROJECT_SOURCE_DIR}/extlibs/libELL/include" "${SOURCE_PATH}" )
+target_include_directories( ${TARGET} PUBLIC $<BUILD_INTERFACE:${INCLUDE_PATH}> $<INSTALL_INTERFACE:include/> )
 
-	set_target_properties( sfgui PROPERTIES DEBUG_POSTFIX -d )
-else()
-	add_definitions( -DSFGUI_STATIC )
-	add_library( sfgui ${SOURCES} )
+if( NOT SFGUI_BUILD_SHARED_LIBS )
+	target_compile_definitions( ${TARGET} PRIVATE SFGUI_STATIC )
+	set_target_properties( ${TARGET} PROPERTIES DEBUG_POSTFIX -s-d )
+	set_target_properties( ${TARGET} PROPERTIES RELEASE_POSTFIX -s )
+	set_target_properties( ${TARGET} PROPERTIES MINSIZEREL_POSTFIX -s )
+else ()
+	set_target_properties( ${TARGET} PROPERTIES DEBUG_POSTFIX -d )
+endif ()
 
-	set_target_properties( sfgui PROPERTIES DEBUG_POSTFIX -s-d )
-	set_target_properties( sfgui PROPERTIES RELEASE_POSTFIX -s )
-	set_target_properties( sfgui PROPERTIES MINSIZEREL_POSTFIX -s )
+if( SFGUI_INCLUDE_FONT )
+	target_compile_definitions( ${TARGET} PRIVATE SFGUI_INCLUDE_FONT )
 endif()
 
+target_link_libraries( ${TARGET} PUBLIC sfml-graphics sfml-window sfml-system ${OPENGL_gl_LIBRARY} )
+
 # Tell the compiler to export when necessary.
-set_target_properties( sfgui PROPERTIES DEFINE_SYMBOL SFGUI_EXPORTS )
+set_target_properties( ${TARGET} PROPERTIES DEFINE_SYMBOL SFGUI_EXPORTS )
 
 # Platform- and compiler-specific options.
 if( WIN32 )
-	set( SFGUI_STATIC_STD_LIBS FALSE CACHE BOOL "Use statically linked standard/runtime libraries? This option must match the one used for SFML." )
+	option( SFGUI_STATIC_STD_LIBS "Use statically linked standard/runtime libraries? This option must match the one used for SFML." OFF)
 
 	# Determine whether we're dealing with a TDM compiler or not
 	if( CMAKE_COMPILER_IS_GNUCXX )
@@ -231,7 +76,8 @@ if( WIN32 )
 		if( SFGUI_BUILD_SHARED_LIBS )
 			message( FATAL_ERROR "\n-> SFGUI_STATIC_STD_LIBS and SFGUI_BUILD_SHARED_LIBS are not compatible.\n-> They lead to multiple runtime environments which results in undefined behavior.\n" )
 		else()
-			add_definitions( -DSFML_STATIC )
+			target_compile_definitions( ${TARGET} PRIVATE SFML_STATIC )
+
 			if( MSVC )
 				foreach( flag CMAKE_CXX_FLAGS CMAKE_CXX_FLAGS_DEBUG CMAKE_CXX_FLAGS_RELEASE )
 					if( ${flag} MATCHES "/MD" )
@@ -239,22 +85,21 @@ if( WIN32 )
 					endif()
 				endforeach()
 			elseif( CMAKE_COMPILER_IS_GNUCXX AND NOT COMPILER_GCC_TDM )
-				set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -static-libgcc -static-libstdc++" )
+				target_compile_options( ${TARGET} PUBLIC -static-libgcc -static-libstdc++ )
 			endif()
 		endif()
 	elseif( COMPILER_GCC_TDM )
-		set( CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -shared-libgcc -shared-libstdc++" )
+		target_compile_options( ${TARGET} PUBLIC -shared-libgcc -shared-libstdc++ )
 	endif()
 
-	add_definitions( -DWIN32 )
-	target_link_libraries( sfgui sfml-graphics sfml-window sfml-system ${OPENGL_gl_LIBRARY} )
+	target_compile_definitions( ${TARGET} PRIVATE WIN32 )
 
 	if( CMAKE_COMPILER_IS_GNUCXX )
 		if( SFGUI_BUILD_SHARED_LIBS )
-			set_target_properties( sfgui PROPERTIES PREFIX "" )
+			set_target_properties( ${TARGET} PROPERTIES PREFIX "" )
 		endif()
 
-		set_target_properties( sfgui PROPERTIES IMPORT_SUFFIX ".a" )
+		set_target_properties( ${TARGET} PROPERTIES IMPORT_SUFFIX ".a" )
 	endif()
 
 	set( SHARE_PATH "." )
@@ -263,12 +108,19 @@ elseif( APPLE )
 	find_library( COREFOUNDATION_LIBRARY CoreFoundation )
 	mark_as_advanced( COREFOUNDATION_LIBRARY )
 
-	include_directories( SYSTEM /System/Library/Frameworks/CoreFoundation.framework/Headers )
-	target_link_libraries( sfgui sfml-graphics sfml-window sfml-system ${OPENGL_gl_LIBRARY} ${COREFOUNDATION_LIBRARY} )
+	add_library( CoreFoundation SHARED IMPORTED )
+	set_target_properties(
+		CoreFoundation PROPERTIES
+			IMPORTED_LOCATION "${COREFOUNDATION_LIBRARY}"
+			INTERFACE_INCLUDE_DIRECTORIES "/System/Library/Frameworks/CoreFoundation.framework/Headers"
+	)
+	
+	target_link_libraries( ${TARGET} PUBLIC CoreFoundation )
 	set( SHARE_PATH "${CMAKE_INSTALL_PREFIX}/share/SFGUI" )
 	set( LIB_PATH "lib" )
 elseif( "${CMAKE_SYSTEM_NAME}" MATCHES "Linux" )
-	target_link_libraries( sfgui sfml-graphics sfml-window sfml-system ${OPENGL_gl_LIBRARY} ${X11_LIBRARIES} )
+	find_package( X11 REQUIRED )
+	target_link_libraries( ${TARGET} PUBLIC ${X11_LIBRARIES} )
 	set( SHARE_PATH "${CMAKE_INSTALL_PREFIX}/share/SFGUI" )
 	
 	if( LIB_SUFFIX )
@@ -277,17 +129,12 @@ elseif( "${CMAKE_SYSTEM_NAME}" MATCHES "Linux" )
 		set( LIB_PATH "lib" )
 	endif()
 else()
-	target_link_libraries( sfgui sfml-graphics sfml-window sfml-system ${OPENGL_gl_LIBRARY} )
 	set( SHARE_PATH "${CMAKE_INSTALL_PREFIX}/share/SFGUI" )
 	set( LIB_PATH "lib" )
 endif()
 
-if( CMAKE_CXX_COMPILER MATCHES ".*clang[+][+]" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" )
-	set( CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wunused-parameter -Wno-long-long -pedantic ${CMAKE_CXX_FLAGS}" )
-	set( CMAKE_C_FLAGS "-Wall -Wextra -Wshadow -Wconversion -Wno-long-long -pedantic ${CMAKE_C_FLAGS}" )
-elseif( CMAKE_COMPILER_IS_GNUCXX )
-	set( CMAKE_CXX_FLAGS "-std=c++11 -Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wunused-parameter -Wno-long-long -pedantic ${CMAKE_CXX_FLAGS}" )
-	set( CMAKE_C_FLAGS "-Wall -Wextra -Wshadow -Wconversion -Wno-long-long -pedantic ${CMAKE_C_FLAGS}" )
+if( CMAKE_CXX_COMPILER MATCHES ".*clang[+][+]" OR CMAKE_CXX_COMPILER_ID STREQUAL "Clang" OR CMAKE_COMPILER_IS_GNUCXX)
+	target_compile_options( SFGUI PRIVATE -Wall -Wextra -Wshadow -Wconversion -Wsign-conversion -Wunused-parameter -Wno-long-long -pedantic )
 endif()
 
 ### EXAMPLES ###
@@ -304,16 +151,17 @@ endif()
 
 ### INSTALL TARGETS ###
 
+add_library(${PROJECT_NAME}::${TARGET} ALIAS ${TARGET})
 install(
-	TARGETS sfgui
+	TARGETS ${TARGET} EXPORT ${PROJECT_NAME}Targets
 	RUNTIME DESTINATION bin COMPONENT bin
 	LIBRARY DESTINATION "${LIB_PATH}" COMPONENT bin
 	ARCHIVE DESTINATION "${LIB_PATH}" COMPONENT dev
 )
 
 install(
-	DIRECTORY include
-	DESTINATION .
+	DIRECTORY ${INCLUDE_PATH}
+	DESTINATION include
 )
 
 install(
@@ -322,6 +170,20 @@ install(
 )
 
 install(
-	FILES cmake/Modules/FindSFGUI.cmake
-	DESTINATION "${SHARE_PATH}/cmake/Modules"
+	EXPORT ${PROJECT_NAME}Targets NAMESPACE ${PROJECT_NAME}:: COMPONENT dev
+	DESTINATION "${SHARE_PATH}/cmake/"
 )
+
+include( CMakePackageConfigHelpers )
+write_basic_package_version_file( ${PROJECT_NAME}ConfigVersion.cmake
+	VERSION ${SFGUI_VERSION}
+	COMPATIBILITY SameMajorVersion )
+
+configure_file(cmake/templates/config.cmake.in ${PROJECT_NAME}Config.cmake @ONLY)
+
+install(
+	FILES ${PROJECT_NAME}Config.cmake ${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}ConfigVersion.cmake
+	DESTINATION "${SHARE_PATH}/cmake/"
+)
+
+export(EXPORT ${PROJECT_NAME}Targets NAMESPACE ${PROJECT_NAME}::)

--- a/cmake/templates/config.cmake.in
+++ b/cmake/templates/config.cmake.in
@@ -1,0 +1,14 @@
+#
+# Configuration file for @PROJECT_NAME@
+#
+# Define Alias library @PROJECT_NAME@::@TARGET@
+
+include( CMakeFindDependencyMacro )
+find_dependency( SFML 2.5 )
+find_dependency( OpenGL )
+
+if( "${CMAKE_SYSTEM_NAME}" MATCHES "Linux" )
+	find_dependency( X11 )
+endif()
+
+include( "${CMAKE_CURRENT_LIST_DIR}/MyLibraryTargets.cmake" )

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,7 @@ cmake_minimum_required( VERSION 2.8 )
 
 function( build_example SAMPLE_NAME SOURCES )
 	add_executable( ${SAMPLE_NAME} ${SOURCES} )
-	target_link_libraries( ${SAMPLE_NAME} sfgui ${SFML_LIBRARIES} ${SFML_DEPENDENCIES} ${OPENGL_gl_LIBRARY} )
+	target_link_libraries( ${SAMPLE_NAME} PRIVATE SFGUI::SFGUI)
 
 	install(
 		TARGETS ${SAMPLE_NAME}

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ function( build_example SAMPLE_NAME SOURCES )
 
 	install(
 		TARGETS ${SAMPLE_NAME}
-		RUNTIME DESTINATION "${SHARE_PATH}/examples" COMPONENT examples
+		RUNTIME DESTINATION "bin" COMPONENT examples
 	)
 
 	install(

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -6,7 +6,7 @@ function( build_example SAMPLE_NAME SOURCES )
 
 	install(
 		TARGETS ${SAMPLE_NAME}
-		RUNTIME DESTINATION "bin" COMPONENT examples
+		RUNTIME DESTINATION "${SHARE_PATH}/examples" COMPONENT examples
 	)
 
 	install(


### PR DESCRIPTION
Hi, I was thinking about using SFGUI for my project, and since I spend a lot of time in my day job writing CMake scripts, I thought I would give a new shine to the configuration of this project. I hope this is not a problem.

If this small rejuvenation project seems like a good idea, I'll be happy to answer to any feedback. I also understand that it may not be of interest.

## Features
 - Switched to a target based system
 - Export configuration files for user-projects retrieval (FindXXX.cmake are usually created for non cmake projects).
 - Added SFGUI to the local cmake package cache (so that you don't need to define `SFGUI_DIR` or things like that)
 - Added name-spaced alias targets
 - Added dependencies transitivity rules (See graphs bellow)
 - Removed redundant code (both internally and with CMake functionalities)

## Known issues
 - Not widely tested (ATM only Void Linux and Windows VS++ 15 2017)
 - Documentation regarding CMake usage may need to be rewritten
 - Broke retro-compatibility with the renaming of the target

## Resources

Those graph were obtained by running `cmake --graphviz=sfgui.dot ..`

**Current master graph:**
![SFGUI Dependency graph master](https://user-images.githubusercontent.com/38338170/46909267-72a0f900-cefd-11e8-915b-0f7725f4eb8e.png)

**PR graph:**
![SFGUI Dependency graph new](https://user-images.githubusercontent.com/38338170/46909265-72a0f900-cefd-11e8-8c1a-7c8cd6153f67.png)
